### PR TITLE
chore: add in jx-release-version during CD pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,6 +34,10 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: next release version
+        id: nextversion
+        uses: jenkins-x-plugins/jx-release-version@v2.2.5
+
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@master
         with:


### PR DESCRIPTION
This change is to debug the next semantic version as determined by `jx-release-version`

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
