### PR TITLE
chore: move the 'interesting categories' check into the pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,6 +41,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Interesting
+        id: interesting
+        if: steps.wait-for-build.outputs.conclusion == 'success'
+        runs: |
+          set -euxo pipefail
+          INTERESTING_CATEGORIES='[💥🚨🎉🐛⚠🚀👷]|:(boom|tada|construction_worker):'
+          gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body' | egrep "$INTERESTING_CATEGORIES"
+
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@master
         if: steps.wait-for-build.outputs.conclusion == 'success'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,8 +46,14 @@ jobs:
         if: steps.wait-for-build.outputs.conclusion == 'success'
         runs: |
           set -euxo pipefail
+          echo $GITHUB_EVENT_NAME
+          # TODO should check if this is a merge to master here.
           INTERESTING_CATEGORIES='[💥🚨🎉🐛⚠🚀👷]|:(boom|tada|construction_worker):'
-          gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body' | egrep "$INTERESTING_CATEGORIES"
+          CATEGORIES=$(gh api /repos/$GITHUB_REPOSITORY/releases | jq -e -r '.[] | select(.draft == true and .name == "next") | .body')
+          echo $CATEGORIES
+
+          echo $CATEGORIES | egrep "$INTERESTING_CATEGORIES"
+          # TODO set an output based on the result of the egrep.
 
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@master


### PR DESCRIPTION
By switching to running the release build after push to master, we've lost the interesting categories check.  This PR adds it back into the release pipeline explicitly.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
