### PR TITLE
fix: for loading configuration values

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -51,8 +51,8 @@ public class CreateRaw extends BaseStep {
     private String input;
     private String inputType;
     private boolean enableCatalog;
-    private PrintStream consoleLogger;
-    private ClassLoader toolClassLoader;
+    private transient PrintStream consoleLogger;
+    private transient ClassLoader toolClassLoader;
 
     @DataBoundConstructor
     public CreateRaw(String input, String inputType, boolean enableCatalog) {
@@ -82,14 +82,15 @@ public class CreateRaw extends BaseStep {
         this.toolClassLoader = toolClassLoader;
     }
 
-    protected String getInput(){
+    public String getInput() {
         return this.input;
     }
-    protected String getInputType(){
+
+    public String getInputType() {
         return this.inputType;
     }
 
-    protected boolean isEnableCatalog() {
+    public boolean isEnableCatalog() {
         return enableCatalog;
     }
 


### PR DESCRIPTION
lets Jenkins load the old configuration values if you click `Configure` after you have created a pipeline using the CreateRaw step

fixes #92