### PR TITLE
fix: improve the logging

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
@@ -15,6 +15,7 @@ import org.waveywaves.jenkins.plugins.tekton.client.TektonUtils.TektonResourceTy
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -112,7 +113,7 @@ public class TaskRunLogWatch implements Runnable{
 
     protected void logMessage(String text) {
         try {
-            this.consoleLogger.write(text.getBytes());
+            this.consoleLogger.write(text.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             logger.warning("failed to log to console: " + e);
         }

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
@@ -26,6 +26,8 @@ import java.util.logging.Logger;
 public class TaskRunLogWatch implements Runnable{
     private static final Logger logger = Logger.getLogger(TaskRunLogWatch.class.getName());
 
+    protected static final HashSet<String> runningPhases = Sets.newHashSet("Running", "Succeeded",  "Failed");
+
     private KubernetesClient kubernetesClient;
     private TaskRun taskRun;
     OutputStream consoleLogger;

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
@@ -1,7 +1,11 @@
 package org.waveywaves.jenkins.plugins.tekton.client.logwatch;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerState;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -9,8 +13,10 @@ import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRun;
 import org.waveywaves.jenkins.plugins.tekton.client.TektonUtils.TektonResourceType;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -51,20 +57,64 @@ public class TaskRunLogWatch implements Runnable{
         }
 
         if (!podName.isEmpty() && taskRunPod != null){
-            Predicate<Pod> succeededState = i -> (i.getStatus().getPhase().equals("Succeeded"));
-            PodResource<Pod> pr = kubernetesClient.pods().inNamespace(taskRunPod.getMetadata().getNamespace()).withName(podName);
+            logMessage("pod " + ns + "/" + podName + ":\n");
+
+            logger.info("waiting for pod " + ns + "/" + podName + " to start running...");
+            Predicate<Pod> succeededState = i -> (runningPhases.contains(i.getStatus().getPhase()));
+            PodResource<Pod> pr = kubernetesClient.pods().inNamespace(ns).withName(podName);
             try {
                 pr.waitUntilCondition(succeededState,60, TimeUnit.MINUTES);
             } catch ( InterruptedException e) {
                 logger.warning("Interrupted Exception Occurred");
             }
+            logger.info("\npod " + podName + " running:");
             List<String> taskRunContainerNames = new ArrayList<String>();
             for (Container c : taskRunPod.getSpec().getContainers()) {
                 taskRunContainerNames.add(c.getName());
             }
-            for (String i : taskRunContainerNames) {
-                pr.inContainer(i).watchLog(this.consoleLogger);
+            for (String containerName : taskRunContainerNames) {
+                // lets write a little header per container
+                logMessage("\n\n" + containerName + ":\n");
+
+                // wait for the container to start
+                logger.info("waiting for pod pod: " + ns + "/" + podName + " container: " + containerName + " to start:");
+
+                Predicate<Pod> containerRunning = i -> {
+                    List<ContainerStatus> statuses = i.getStatus().getContainerStatuses();
+                    for (ContainerStatus status : statuses) {
+                        if (status.getName().equals(containerName)) {
+                            ContainerState state = status.getState();
+                            if (state != null) {
+                                ContainerStateTerminated terminatedState = state.getTerminated();
+                                if (terminatedState != null && terminatedState.getStartedAt() != null) {
+                                    logger.info("container " + containerName + " completed");
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }
+                    }
+                    return false;
+                };
+                try {
+                    pr.waitUntilCondition(containerRunning,60, TimeUnit.MINUTES);
+                } catch ( InterruptedException e) {
+                    logger.warning("Interrupted Exception Occurred");
+                }
+
+                pr.inContainer(containerName).watchLog(this.consoleLogger);
             }
+        } else {
+            logger.info("no pod could be found for TaskRun " + ns + "/" + taskRun.getMetadata().getName());
+        }
+    }
+
+
+    protected void logMessage(String text) {
+        try {
+            this.consoleLogger.write(text.getBytes());
+        } catch (IOException e) {
+            logger.warning("failed to log to console: " + e);
         }
     }
 }

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/TaskRunLogWatch.java
@@ -26,8 +26,6 @@ import java.util.logging.Logger;
 public class TaskRunLogWatch implements Runnable{
     private static final Logger logger = Logger.getLogger(TaskRunLogWatch.class.getName());
 
-    protected static final HashSet<String> runningPhases = Sets.newHashSet("Running", "Succeeded",  "Failed");
-
     private KubernetesClient kubernetesClient;
     private TaskRun taskRun;
     OutputStream consoleLogger;
@@ -40,6 +38,7 @@ public class TaskRunLogWatch implements Runnable{
 
     @Override
     public void run() {
+        HashSet<String> runningPhases = Sets.newHashSet("Running", "Succeeded", "Failed");
         String ns = taskRun.getMetadata().getNamespace();
         List<Pod> pods = kubernetesClient.pods().inNamespace(ns).list().getItems();
         Pod taskRunPod = null;


### PR DESCRIPTION
so we don't wait for the entire pipeline to complete before generating any output; but instead wait for the Pod to start Running and then logging each container in turn when that container has completed

fixes #59