### PR TITLE
chore: improve labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,13 @@
 ---
 version: 1
 labels:
+  - label: "in progress"
+    title: "^WIP:.*"
+  - label: "in progress"
+    title: "^wip:.*"
+  - label: "in progress"
+    mergeable: false
+
   - title: "feat.*"
     label: "enhancement"
 
@@ -10,6 +17,9 @@ labels:
     label: "bug"
 
   - title: "chore(deps).*"
+    label: "dependencies"
+
+  - branch: "^dependabot/.*"
     label: "dependencies"
 
   - title: "chore.*"


### PR DESCRIPTION
This should stop the dependabot `dependencies` label from being removed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
