### PR TITLE
fix: handle running better outside of the controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <mockwebserver.version>0.1.8</mockwebserver.version>
         <junit-jupiter-engine.version>5.6.2</junit-jupiter-engine.version>
-        <jx-pipeline.version>0.0.120</jx-pipeline.version>
+        <jx-pipeline.version>0.0.121</jx-pipeline.version>
     </properties>
 
     <licenses>

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -367,7 +367,9 @@ public class CreateRaw extends BaseStep {
     private byte[] processTektonCatalog(EnvVars envVars, File dir, File file, byte[] data) throws Exception {
         boolean deleteInputFile = false;
         if (file == null) {
-            file = File.createTempFile("tekton-input-", ".yaml", dir);
+            // the following fails when not running in the controller so lets not use a temp file for now
+            //file = File.createTempFile("tekton-input-", ".yaml", dir);
+            file = new File(dir, "tekton-input-pipeline.yaml");
             Files.write(data, file);
             logger.info("saved file: " + file.getPath());
         }

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -372,7 +372,9 @@ public class CreateRaw extends BaseStep {
             logger.info("saved file: " + file.getPath());
         }
 
-        File outputFile = File.createTempFile("tekton-effective-", ".yaml", dir);
+        // the following fails when not running in the controller so lets not use a temp file for now
+        //File outputFile = File.createTempFile("tekton-effective-", ".yaml", dir);
+        File outputFile = new File(dir, "tekton-effective-pipeline.yaml");
 
         String filePath = file.getPath();
         String binary = ToolUtils.getJXPipelineBinary(getToolClassLoader());


### PR DESCRIPTION
the createTempFile() with a dir tends to fail if running in an agent so lets use a canonical path instead to avoid breaking with agents