### PR TITLE
fix: copy remote files locally if we are in a remote agent

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -357,7 +357,10 @@ public class CreateRaw extends BaseStep {
                     logger.info("getting the remote file: " + remotePath + " copying to local file " + inputFile);
 
                     FilePath inputFilePath = new FilePath(inputFile);
-                    inputFilePath.getParent().mkdirs();
+                    FilePath parent = inputFilePath.getParent();
+                    if (parent != null) {
+                        parent.mkdirs();
+                    }
 
                     try {
                         FilePath newFile = new FilePath(channel, remotePath.toString());


### PR DESCRIPTION
if the plugin is used in tekton catalog mode inside an agent we can't see the workspace files; so lets copy the remote workspace file locally if we need to

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
