### PR TITLE
fix: update labeler config to match at the start of the line

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,24 +6,24 @@ labels:
   - label: "in progress"
     title: "^wip:.*"
 
-  - title: "feat.*"
+  - title: "^feat.*"
     label: "enhancement"
 
-  - title: "bug.*"
+  - title: "^bug.*"
     label: "bug"
-  - title: "fix.*"
+  - title: "^fix.*"
     label: "bug"
 
-  - title: "chore(deps).*"
+  - title: "^chore(deps).*"
     label: "dependencies"
 
   - branch: "^dependabot/.*"
     label: "dependencies"
 
-  - title: "chore.*"
+  - title: "^chore.*"
     label: "chore"
 
-  - title: "docs.*"
+  - title: "^docs.*"
     label: "documentation"
 
   - files:


### PR DESCRIPTION
This should stop duplicate labels from being added to PRs

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
