### PR TITLE
fix: wait for pod to exist

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/PipelineRunLogWatch.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/logwatch/PipelineRunLogWatch.java
@@ -14,19 +14,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 public class PipelineRunLogWatch implements Runnable {
+
     private static final Logger LOGGER = Logger.getLogger(PipelineRunLogWatch.class.getName());
+
+    private static final String PIPELINE_TASK_LABEL_NAME = "tekton.dev/pipelineTask";
+    private static final String PIPELINE_RUN_LABEL_NAME = "tekton.dev/pipelineRun";
+
+    private final PipelineRun pipelineRun;
 
     private KubernetesClient kubernetesClient;
     private TektonClient tektonClient;
-    private PipelineRun pipelineRun;
     private Exception exception;
     OutputStream consoleLogger;
 
-    ConcurrentHashMap<String, TaskRun> taskRunsOnWatch = new ConcurrentHashMap<String, TaskRun>();
-    ConcurrentHashMap<String, Boolean> taskRunsWatchDone = new ConcurrentHashMap<String, Boolean>();
+    //ConcurrentHashMap<String, TaskRun> taskRunsOnWatch = new ConcurrentHashMap<String, TaskRun>();
+    //ConcurrentHashMap<String, Boolean> taskRunsWatchDone = new ConcurrentHashMap<String, Boolean>();
 
-    private final String pipelineTaskLabelName = "tekton.dev/pipelineTask";
-    private final String pipelineRunLabelName = "tekton.dev/pipelineRun";
+
 
     public PipelineRunLogWatch(KubernetesClient kubernetesClient, TektonClient tektonClient, PipelineRun pipelineRun, OutputStream consoleLogger) {
         this.kubernetesClient = kubernetesClient;
@@ -54,7 +58,7 @@ public class PipelineRunLogWatch implements Runnable {
             String pipelineTaskName = pt.getName();
             LOGGER.info("Streaming logs for PipelineTask namespace=" + ns + ", runName=" + pipelineRunName + ", taskName=" + pipelineTaskName);
             ListOptions lo = new ListOptions();
-            String selector = String.format("%s=%s,%s=%s", pipelineTaskLabelName, pipelineTaskName, pipelineRunLabelName, pipelineRunName);
+            String selector = String.format("%s=%s,%s=%s", PIPELINE_TASK_LABEL_NAME, pipelineTaskName, PIPELINE_RUN_LABEL_NAME, pipelineRunName);
             lo.setLabelSelector(selector);
 
             // the tekton operator may not have created the TasksRuns yet so lets wait a little bit for them to show up

--- a/src/test/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/JenkinsFreestyleTest.java
+++ b/src/test/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/JenkinsFreestyleTest.java
@@ -81,7 +81,7 @@ public class JenkinsFreestyleTest {
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(1));
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Legacy code started this job"));
@@ -113,7 +113,7 @@ public class JenkinsFreestyleTest {
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(1));
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Legacy code started this job"));
@@ -199,7 +199,7 @@ public class JenkinsFreestyleTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods/hello-world-pod")
@@ -219,7 +219,7 @@ public class JenkinsFreestyleTest {
 
         FreeStyleBuild b = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Legacy code started this job"));
@@ -308,7 +308,7 @@ public class JenkinsFreestyleTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods/hello-world-pod")
@@ -328,7 +328,7 @@ public class JenkinsFreestyleTest {
 
         FreeStyleBuild b = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Legacy code started this job"));

--- a/src/test/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/JenkinsPipelineTest.java
+++ b/src/test/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/JenkinsPipelineTest.java
@@ -19,11 +19,8 @@ import io.fabric8.tekton.pipeline.v1beta1.TaskBuilder;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunBuilder;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunList;
 import io.fabric8.tekton.pipeline.v1beta1.TaskRunListBuilder;
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -32,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
-import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.waveywaves.jenkins.plugins.tekton.client.TektonUtils;
 import org.waveywaves.jenkins.plugins.tekton.client.ToolUtils;
@@ -85,7 +81,7 @@ public class JenkinsPipelineTest {
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(1));
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Extracting: .tekton/task.yaml"));
@@ -125,7 +121,7 @@ public class JenkinsPipelineTest {
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(1));
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Extracting: .tekton/task.yaml"));
@@ -169,7 +165,7 @@ public class JenkinsPipelineTest {
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(1));
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("Extracting: .tekton/task.yaml"));
@@ -258,7 +254,7 @@ public class JenkinsPipelineTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/test/pods/hello-world-pod")
@@ -291,7 +287,7 @@ public class JenkinsPipelineTest {
 
         WorkflowRun b = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("[Pipeline] tektonCreateRaw"));
@@ -384,7 +380,7 @@ public class JenkinsPipelineTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods/hello-world-pod")
@@ -417,7 +413,7 @@ public class JenkinsPipelineTest {
 
         WorkflowRun b = jenkinsRule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("[Pipeline] tektonCreateRaw"));
@@ -516,7 +512,7 @@ public class JenkinsPipelineTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods/hello-world-pod")
@@ -549,7 +545,7 @@ public class JenkinsPipelineTest {
 
         WorkflowRun b = jenkinsRule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("[Pipeline] tektonCreateRaw"));
@@ -643,7 +639,7 @@ public class JenkinsPipelineTest {
                 .addToItems(pod)
                 .build();
 
-        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods")
+        kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods?labelSelector=tekton.dev%2FtaskRun%3DtestTaskRun")
                 .andReturn(HttpURLConnection.HTTP_OK, podList).once();
 
         kubernetesRule.expect().get().withPath("/api/v1/namespaces/tekton-pipelines/pods/hello-world-pod")
@@ -676,7 +672,7 @@ public class JenkinsPipelineTest {
 
         WorkflowRun b = jenkinsRule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0).get());
 
-        String log = jenkinsRule.getLog(b);
+        String log = JenkinsRule.getLog(b);
         System.out.println(log);
 
         assertThat(log, containsString("[Pipeline] tektonCreateRaw"));
@@ -687,10 +683,6 @@ public class JenkinsPipelineTest {
         assertThat(log, containsString("Whoop! This is the pod log"));
 
         assertThat(kubernetesRule.getMockServer().getRequestCount(), is(9));
-    }
-
-    private String contents(String filename) throws IOException {
-        return IOUtils.toString(this.getClass().getResourceAsStream(filename), StandardCharsets.UTF_8.name());
     }
 
     private OwnerReference ownerReference(String uid) {


### PR DESCRIPTION
Implement a retry whilst waiting for a pod to start, sometimes the taskrun can exist and be running before the pod itself exists

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
