### PR TITLE
Print log to console and set build result to FAILURE

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -423,6 +423,8 @@ public class CreateRaw extends BaseStep {
                 List<TektonResourceType> kind = TektonUtils.getKindFromInputStream(new ByteArrayInputStream(data), this.getInputType());
                 if (kind.size() > 1){
                     LOGGER.warning("Multiple Objects in YAML not supported yet");
+                    logMessage("Multiple Objects in YAML not supported yet");
+                    run.setResult(Result.FAILURE);
                 } else {
                     resourceType = kind.get(0);
                     LOGGER.info("creating kind " + resourceType.name());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
When there are multiple objects in YAML, the job build result is SUCCESS and the build console has no associated logs.
In fact multiple objects in YAML not supported yet, but the log only be found in the jenkins controller console.
So print log to build console and set build result to FAILURE.
