### PR TITLE
fix: corrected the NullPointerException when delete resource

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/delete/DeleteRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/delete/DeleteRaw.java
@@ -1,5 +1,6 @@
 package org.waveywaves.jenkins.plugins.tekton.client.build.delete;
 
+import com.google.common.base.Strings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -41,7 +42,8 @@ public class DeleteRaw extends BaseStep {
         super();
         this.resourceType = resourceType;
         this.resourceName = deleteAllStatus != null ? deleteAllStatus.resourceName : null;
-        setTektonClient(TektonUtils.getTektonClient(clusterName));
+        this.clusterName = clusterName;
+        setTektonClient(TektonUtils.getTektonClient(getClusterName()));
     }
 
     public static class DeleteAllBlock {
@@ -53,11 +55,23 @@ public class DeleteRaw extends BaseStep {
         }
     }
 
+    public String getClusterName() {
+        if (Strings.isNullOrEmpty(clusterName)) {
+            clusterName = TektonUtils.DEFAULT_CLIENT_KEY;
+        }
+        return clusterName;
+    }
     public String getResourceType(){
         return this.resourceType;
     }
     public String getResourceName(){
         return this.resourceName;
+    }
+
+    @DataBoundSetter
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+        setTektonClient(TektonUtils.getTektonClient(getClusterName()));
     }
 
     @DataBoundSetter
@@ -73,6 +87,8 @@ public class DeleteRaw extends BaseStep {
     private TektonResourceType getTypedResourceType(){
         return TektonResourceType.valueOf(getResourceType());
     }
+
+
 
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {

--- a/src/main/resources/org/waveywaves/jenkins/plugins/tekton/client/build/delete/DeleteRaw/config.jelly
+++ b/src/main/resources/org/waveywaves/jenkins/plugins/tekton/client/build/delete/DeleteRaw/config.jelly
@@ -4,7 +4,7 @@
         <f:select name="resourceType"></f:select>
     </f:entry>
     <f:entry title="Cluster Name" field="clusterName">
-        <f:select name="inputType"></f:select>
+        <f:select name="clusterName"></f:select>
     </f:entry>
     <f:block>
         <f:optionalBlock


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

fix: corrected the NullPointerException when delete resource

When I delete resource, the build was failure and the console log of it as follows:
```
ERROR: Build step failed with exception
java.lang.NullPointerException
	at org.waveywaves.jenkins.plugins.tekton.client.build.delete.DeleteRaw.deleteTaskRun(DeleteRaw.java:124)
	at org.waveywaves.jenkins.plugins.tekton.client.build.delete.DeleteRaw.deleteWithResourceSpecificClient(DeleteRaw.java:91)
	at org.waveywaves.jenkins.plugins.tekton.client.build.delete.DeleteRaw.runDelete(DeleteRaw.java:83)
	at org.waveywaves.jenkins.plugins.tekton.client.build.delete.DeleteRaw.perform(DeleteRaw.java:79)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:80)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:803)
	at hudson.model.Build$BuildExecution.build(Build.java:197)
	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:513)
	at hudson.model.Run.execute(Run.java:1907)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Build step 'Tekton : Delete Resource (Raw)' marked build as failure
```

Now delete resource can run successfully.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
