### PR TITLE
fix: persist cluster configuration on disk and in memory

### DIFF
--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/global/TektonGlobalConfiguration.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/global/TektonGlobalConfiguration.java
@@ -17,7 +17,7 @@ import static java.util.logging.Level.SEVERE;
 @Extension
 public class TektonGlobalConfiguration extends GlobalConfiguration {
     private static final Logger logger = Logger.getLogger(TektonGlobalConfiguration.class.getName());
-    private transient List<ClusterConfig> clusterConfigs = new ArrayList<>();
+    private List<ClusterConfig> clusterConfigs = new ArrayList<>();
 
     public TektonGlobalConfiguration(){
         load();
@@ -39,7 +39,8 @@ public class TektonGlobalConfiguration extends GlobalConfiguration {
     @Override
     public boolean configure(final StaplerRequest req, final JSONObject formData) {
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-         setClusterConfigs(req.bindJSONToList(ClusterConfig.class, formData.get("clusterConfigs")));
+        setClusterConfigs(req.bindJSONToList(ClusterConfig.class, formData.get("clusterConfigs")));
+        configChange();
         save();
         return true;
     }


### PR DESCRIPTION
Tekton Cluster configuration is not persisted on disk (save/load) and is lost at next reboot. Moreover, configuration update are not properly stored in memory, preventing users to access to new configuration added (other than the default one).

1. Removed the `transient` keyword to the config list (clusterConfigs) which was preventing the config to be saved/loaded by XStream to XML.
2. Added an explicit call to configChange in order to update the in memory configuration in TektonUtils. 

Fixes #106

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
