### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,10 +16,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: next release version
         id: nextversion

--- a/.github/workflows/e2e.disabled
+++ b/.github/workflows/e2e.disabled
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
 
       - name: Build

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Javadoc

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v2.4.0
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: SpotBugs


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage
