### PR TITLE
chore: rename default branch from master to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,10 +3,10 @@ name: Build
 on:
   push:
     branches: 
-      - master
+      - main
   pull_request:
     branches: 
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -3,7 +3,7 @@ name: Jenkins Security Scan
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ name: Test
 on:
   push:
     branches: 
-      - master
+      - main
   pull_request:
     branches: 
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
**Proposed by @krisstern**

### Summary:
- Renamed the default branch from `master` to `main`.
- Updated all hardcoded references to `master` in GitHub Actions workflows (`.github/workflows/*.yml`).

### To Do (after merge):
- Set the default branch to **`main`** in the repository settings.
- Delete the `master` branch if it is no longer needed.
