### PR TITLE
fix: resolve missing CreateRaw build step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
         <jenkins-test-harness.version>2462.v7cd38b_7a_361b_</jenkins-test-harness.version>
         <kubernetes-server-mock.version>5.4.1</kubernetes-server-mock.version>
         <tekton-client.version>5.4.1</tekton-client.version>
-        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>	3.2.5</maven-surefire-plugin.version>
         <mockwebserver.version>0.1.8</mockwebserver.version>
-        <junit-jupiter-engine.version>5.12.2</junit-jupiter-engine.version>
+        <junit-jupiter-engine.version>5.6.2</junit-jupiter-engine.version>
         <jx-pipeline.version>0.1.5</jx-pipeline.version>
     </properties>
 
@@ -65,6 +65,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.9</version>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>checks-api</artifactId>
         </dependency>
@@ -85,7 +95,6 @@
             <version>${kubernetes-server-mock.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jackson2-api</artifactId>
@@ -118,32 +127,6 @@
             <artifactId>pipeline-utility-steps</artifactId>
             <scope>test</scope>
         </dependency>
-        
-        <!-- E2E Testing Dependencies -->
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <version>${jenkins-test-harness.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>1.21.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter-engine.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit-jupiter-engine.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -151,14 +134,14 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>5054.v620b_5d2b_d5e6</version>
+                <version>4948.vcf1d17350668</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.17.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
@@ -173,7 +156,7 @@
             <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
-                <version>3.15.0</version>
+                <version>1.17.2</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
@@ -183,7 +166,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>logging-interceptor</artifactId>
-                <version>5.1.0</version>
+                <version>3.14.9</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.activation</groupId>
@@ -243,7 +226,7 @@
                 <extensions>true</extensions>
             </plugin>
 
-            <!-- <plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.7</version>
@@ -254,54 +237,6 @@
                     </formats>
                     <check />
                 </configuration>
-            </plugin> -->
-            
-            <!-- Maven Surefire Plugin for running tests -->
-            <!-- JaCoCo for code coverage -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.13</version>
-
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals><goal>prepare-agent</goal></goals>
-                    </execution>
-
-                    <execution>
-                        <id>report</id>
-                        <phase>verify</phase>
-                        <goals><goal>report</goal></goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <configuration>
-                    <excludes>
-                        <!-- Exclude E2E tests from regular test runs by default -->
-                        <exclude>**/*E2ETest.java</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <!-- Regular unit tests -->
-                    <execution>
-                        <id>unit-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*E2ETest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -353,49 +288,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        
-        <!-- E2E Testing Profile -->
-        <profile>
-            <id>e2e-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>e2e-tests</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <includes>
-                                        <include>**/*E2ETest.java</include>
-                                    </includes>
-                                    <excludes>
-                                        <!-- No exclusions for E2E profile -->
-                                    </excludes>
-                                    <systemPropertyVariables>
-                                        <KIND_CLUSTER_NAME>${KIND_CLUSTER_NAME}</KIND_CLUSTER_NAME>
-                                        <TEKTON_VERSION>${TEKTON_VERSION}</TEKTON_VERSION>
-                                    </systemPropertyVariables>
-                                    <!-- E2E tests typically take longer -->
-                                    <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-                                    <parallel>classes</parallel>
-                                    <threadCount>1</threadCount>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-            <properties>
-                <KIND_CLUSTER_NAME>tekton-e2e-test</KIND_CLUSTER_NAME>
-                <TEKTON_VERSION>v1.0.0</TEKTON_VERSION>
-            </properties>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
+++ b/src/main/java/org/waveywaves/jenkins/plugins/tekton/client/build/create/CreateRaw.java
@@ -73,7 +73,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-@Symbol("tektonCreateRaw")
 public class CreateRaw extends BaseStep {
     private static final Logger LOGGER = Logger.getLogger(CreateRaw.class.getName());
 


### PR DESCRIPTION
Fix duplicate https://github.com/symbol("tektonCreateRaw") annotations that were causing the "Create Resource (Raw)" build step to not appear in Jenkins UI

Fixes #441 - Not found Create Resource (Raw) Item